### PR TITLE
shebang using env instead of hardcoded ruby

### DIFF
--- a/files/dehydrated_job_runner.rb
+++ b/files/dehydrated_job_runner.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/ruby
+#!/usr/bin/env ruby
 
 require 'json'
 require 'open3'


### PR DESCRIPTION
Using a hardcoded path is a problem on systems with a different *PATH* setting, for example NixOS,
BSDs, and systems with programs installed in userspace.
`/usr/bin/env` is required by POSIX and therefore isn't a problem but the preferred way.