### PR TITLE
allow empty dehydrated::hook for http-01

### DIFF
--- a/files/dehydrated_job_runner.rb
+++ b/files/dehydrated_job_runner.rb
@@ -256,7 +256,7 @@ def handle_request(fqdn, dn, config)
       return ['Domain validation hook failed', stdout, stderr, status] if status > 0
     end
 
-    unless dehydrated_hook_script.empty?
+    unless dehydrated_hook_script.nil? || dehydrated_hook_script.empty?
       unless File.exist?(dehydrated_hook_script) && File.executable?(dehydrated_hook_script)
         return ['Configured Dehydrated hook does not exist or is not executable',
                 dehydrated_hook_script,
@@ -411,7 +411,7 @@ write_status_file(
 #{"base_dir":"/etc/dehydrated","crt_dir":"/etc/dehydrated/certs","csr_dir":"/etc/dehydrated/csr","dehydrated_base_dir":"/opt/dehydrated","dehydrated_host":"fuzz.foobar.com","dehydrated_puppetmaster":"puppet.foobar.com","dehydrated_requests_dir":"/opt/dehydrated/requests","dehydrated_requests_config":"/opt/dehydrated/requests.json","key_dir":"/etc/dehydrated/private"}
 
 
-# dehydrated@fuzz:~/dehydrated$ ./dehydrated  --config /opt/dehydrated/requests/fuzz.foobar.com/tt.foobar.com/tt.foobar.com.config --accept-terms --register 
+# dehydrated@fuzz:~/dehydrated$ ./dehydrated  --config /opt/dehydrated/requests/fuzz.foobar.com/tt.foobar.com/tt.foobar.com.config --accept-terms --register
 # # INFO: Using main config file /opt/dehydrated/requests/fuzz.foobar.com/tt.foobar.com/tt.foobar.com.config
 # + Generating account key...
 # + Registering account key with ACME server...
@@ -434,7 +434,7 @@ write_status_file(
 #   "initialIp": "2a02:16a8:dc4:a01::211",
 #   "createdAt": "2018-10-02T16:39:08Z",
 #   "status": "valid"
-# }dehydrated@fuzz:~/dehydrated$ 
+# }dehydrated@fuzz:~/dehydrated$
 # dehydrated@fuzz:~/dehydrated$ vim /opt/dehydrated/requests/fuzz.foobar.com/tt.foobar.com/tt.foobar.com.config
 # dehydrated@fuzz:~/dehydrated$ ./dehydrated  --config /opt/dehydrated/requests/fuzz.foobar.com/tt.foobar.com/tt.foobar.com.config --account
 # # INFO: Using main config file /opt/dehydrated/requests/fuzz.foobar.com/tt.foobar.com/tt.foobar.com.config
@@ -456,5 +456,5 @@ write_status_file(
 #   "initialIp": "2a02:16a8:dc4:a01::211",
 #   "createdAt": "2018-10-02T16:39:08Z",
 #   "status": "valid"
-# }dehydrated@fuzz:~/dehydrated$ 
-# 
+# }dehydrated@fuzz:~/dehydrated$
+#

--- a/manifests/certificate.pp
+++ b/manifests/certificate.pp
@@ -78,7 +78,7 @@ define dehydrated::certificate(
   Integer[768] $dh_param_size = $::dehydrated::dh_param_size,
   Stdlib::Fqdn $dehydrated_host = $::dehydrated::dehydrated_host,
   Hash $dehydrated_environment = $::dehydrated::dehydrated_environment,
-  Dehydrated::Hook $dehydrated_hook = $::dehydrated::dehydrated_hook,
+  Optional[Dehydrated::Hook] $dehydrated_hook = $::dehydrated::dehydrated_hook,
   String $letsencrypt_ca = $::dehydrated::letsencrypt_ca,
   Optional[Dehydrated::Hook] $dehydrated_domain_validation_hook = $::dehydrated::dehydrated_domain_validation_hook,
   Optional[String] $key_password = undef,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,7 +20,7 @@
 # @param base_dir
 #   The base directory where keys/csr/certs are stored.
 #   Defaults to:
-#   - on $::os['family']=='Debian': /etc/dehydrated 
+#   - on $::os['family']=='Debian': /etc/dehydrated
 #   - on other Linux/Unix systems: /etc/pki/dehydrated
 #   - on windows: C:\LE_certs.
 # @param crt_dir
@@ -161,7 +161,7 @@ class dehydrated
   Array $dehydrated_host_packages = $::dehydrated::params::dehydrated_host_packages,
   Hash $dehydrated_environment = $::dehydrated::params::dehydrated_environment,
   Optional[Dehydrated::Hook] $dehydrated_domain_validation_hook = $::dehydrated::params::dehydrated_domain_validation_hook,
-  Dehydrated::Hook $dehydrated_hook = "${challengetype}.sh",
+  Optional[Dehydrated::Hook] $dehydrated_hook = "${challengetype}.sh",
   Optional[Dehydrated::Email] $dehydrated_contact_email = $::dehydrated::params::dehydrated_contact_email,
 
   Boolean $manage_user = $::dehydrated::params::manage_user,


### PR DESCRIPTION
Currently, the hook is a hard requirement.

For http-01, no hook is required, so let's change it to optional.