### PR TITLE
Replace usages of `has_key` with `in` operator of puppet language

### DIFF
--- a/manifests/certificate/collect.pp
+++ b/manifests/certificate/collect.pp
@@ -40,25 +40,25 @@ define dehydrated::certificate::collect (
     # we are on a non-puppetmaster host
     # use facter to retrieve files.
     if (
-      has_key($facts, 'dehydrated_certificates') and
-      has_key($facts['dehydrated_certificates'], $request_fqdn) and
-      has_key($facts['dehydrated_certificates'][$request_fqdn], $request_dn)
+      'dehydrated_certificates' in $facts and
+      $request_fqdn in $facts['dehydrated_certificates'] and
+      $request_dn in $facts['dehydrated_certificates'][$request_fqdn]
     ) {
       $config = $facts['dehydrated_certificates'][$request_fqdn][$request_dn]
-      if has_key($config, 'crt') {
+      if 'crt' in $config {
         $crt = $config['crt']
       } else {
         $crt = undef
       }
       if (
-        has_key($config, 'ocsp') and
+        'ocsp' in $config and
         $config['ocsp'] =~ Stdlib::Base64
       ) {
         $ocsp = String(Binary($config['ocsp']))
       } else {
         $ocsp = undef
       }
-      if has_key($config, 'ca') {
+      if 'ca' in $config {
         $ca = $config['ca']
       } else {
         $ca = undef

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -230,7 +230,7 @@ class dehydrated (
 
     Dehydrated::Certificate::Request<<| tag == "dehydrated-request-for-${dehydrated_host}" |>>
 
-    if has_key($facts, 'dehydrated_certificates') {
+    if 'dehydrated_certificates' in $facts {
       $dehydrated_certificates = $facts['dehydrated_certificates']
       $dehydrated_certificates.each |Stdlib::Fqdn $_request_fqdn, Hash $_certificate_configs| {
         $_certificate_configs.each |Dehydrated::DN $_request_dn, $_request_config| {


### PR DESCRIPTION
Hi Bernd,

with stdlib 9.0.0 puppetlabs removed the has_key function from the library.

https://github.com/puppetlabs/puppetlabs-stdlib/pull/1319

https://forge.puppet.com/modules/puppetlabs/stdlib/changelog#v900---2023-05-30

The attached commit replaces the usages of has_key with the `'x' in $hash` expression.

After fixing this I can use the module fine with the latest version of all dependencies:
* stdlib 9.2.0
* concat 9.0.0
* vcsrepo 6.1.0

Edit: still should work with older versions too since the in expression has been around for ages.

LG,
Flo :) 