### PR TITLE
Insert Newline after end certificate if necessary

### DIFF
--- a/files/dehydrated_job_runner.rb
+++ b/files/dehydrated_job_runner.rb
@@ -161,6 +161,10 @@ def sign_csr(dehydrated_config, csr_file, crt_file, ca_file)
 
   stdout, stderr, status = run_dehydrated(dehydrated_config, "--signcsr '#{csr_file}'")
   if status.zero?
+    if not stdout.strip().include? "\n\n"
+      stdout=stdout.gsub("-----END CERTIFICATE-----", "-----END CERTIFICATE-----\n").strip()
+    end
+
     certs = stdout.split("\n\n")
     if certs.size < 2
       stdout = "# -- CA certificate missing? -- \n #{stdout}"

--- a/lib/puppet/provider/dehydrated_csr/openssl.rb
+++ b/lib/puppet/provider/dehydrated_csr/openssl.rb
@@ -127,7 +127,13 @@ Puppet::Type.type(:dehydrated_csr).provide(:openssl) do
     attributes.each do |attribute|
       request.add_attribute(attribute)
     end
-    request.public_key = private_key.public_key
+    # Special Handling for ECC
+    if private_key.class == OpenSSL::PKey::EC
+      request.public_key = private_key
+    else
+      request.public_key = private_key.public_key
+    end
+
     openssl_digest = OpenSSL::Digest.new(digest)
     request.sign(private_key, openssl_digest)
     request.to_pem


### PR DESCRIPTION
Because some CAs prefer to not have two newlines between certificates (for example sectigo..)
Insert Newline after End certificate, only if the file does not contain any "double newlines"