### PR TITLE
Single account

### DIFF
--- a/files/dehydrated_job_runner.rb
+++ b/files/dehydrated_job_runner.rb
@@ -241,7 +241,10 @@ def handle_request(fqdn, dn, config)
                   )
 
   # register / update account
-  account_json = File.join(request_fqdn_dir, 'accounts', letsencrypt_ca_hash, 'registration_info.json')
+  # prior to 2024-04, the config did not contain the request_account_dir.  Fall back to the
+  # previous method if we don't have request_account_dir in the config (yet?).
+  accounts_dir = config['request_account_dir'] || File.join(request_fqdn_dir, 'accounts')
+  account_json = File.join(accounts_dir, letsencrypt_ca_hash, 'registration_info.json')
   if !File.exist?(account_json)
     stdout, stderr, status = register_account(dehydrated_config)
     return ['Account registration failed', stdout, stderr, status] if status > 0

--- a/manifests/certificate/request.pp
+++ b/manifests/certificate/request.pp
@@ -32,21 +32,13 @@ define dehydrated::certificate::request (
   $dehydrated_host = $config['dehydrated_host']
   $dehydrated_environment = $config['dehydrated_environment']
   $dehydrated_hook = $config['dehydrated_hook']
-  if (!$dehydrated_hook or $dehydrated_hook == '') {
-    $dehydrated_hook_script = undef
-  } else {
-    $dehydrated_hook_script = join( [$dehydrated::dehydrated_hooks_dir, $dehydrated_hook],
-      $dehydrated::params::path_seperator,
-    )
+  $dehydrated_hook_script = if $dehydrated_hook and $dehydrated_hook != '' {
+    [$dehydrated::dehydrated_hooks_dir, $dehydrated_hook].join($dehydrated::params::path_seperator)
   }
 
   $dehydrated_domain_validation_hook = $config['dehydrated_domain_validation_hook']
-  if (!$dehydrated_domain_validation_hook or $dehydrated_domain_validation_hook == '') {
-    $dehydrated_domain_validation_hook_script = undef
-  } else {
-    $dehydrated_domain_validation_hook_script = join( [$dehydrated::dehydrated_hooks_dir, $dehydrated_domain_validation_hook],
-      $dehydrated::params::path_seperator,
-    )
+  $dehydrated_domain_validation_hook_script = if $dehydrated_domain_validation_hook and $dehydrated_domain_validation_hook != '' {
+    [$dehydrated::dehydrated_hooks_dir, $dehydrated_domain_validation_hook].join($dehydrated::params::path_seperator)
   }
 
   $letsencrypt_ca = $config['letsencrypt_ca']
@@ -56,30 +48,15 @@ define dehydrated::certificate::request (
 
   # added later, handle missing config
   $_preferred_chain = $config.dig('preferred_chain')
-  if !empty($_preferred_chain) {
-    $preferred_chain = $_preferred_chain
-  } else {
-    $preferred_chain = undef
-  }
+  $preferred_chain = if !empty($_preferred_chain) { $_preferred_chain }
 
   $dehydrated_requests_dir = $dehydrated::dehydrated_requests_dir
 
-  $request_fqdn_dir = join( [$dehydrated_requests_dir, $request_fqdn],
-    $dehydrated::params::path_seperator
-  )
-  $request_base_dir = join( [$request_fqdn_dir, $base_filename],
-    $dehydrated::params::path_seperator
-  )
-  $request_account_dir = join( [$request_fqdn_dir, 'accounts'],
-    $dehydrated::params::path_seperator
-  )
-
-  $csr_file = join( [$request_base_dir, "${base_filename}.csr"],
-    $dehydrated::params::path_seperator
-  )
-  $dehydrated_config = join( [$request_base_dir, "${base_filename}.config"],
-    $dehydrated::params::path_seperator
-  )
+  $request_fqdn_dir = [$dehydrated_requests_dir, $request_fqdn].join($dehydrated::params::path_seperator)
+  $request_base_dir = [$request_fqdn_dir, $base_filename].join($dehydrated::params::path_seperator)
+  $request_account_dir = [$request_fqdn_dir, 'accounts'].join($dehydrated::params::path_seperator)
+  $csr_file = [$request_base_dir, "${base_filename}.csr"].join($dehydrated::params::path_seperator)
+  $dehydrated_config = [$request_base_dir, "${base_filename}.config"].join($dehydrated::params::path_seperator)
 
   $letsencrypt_ca_url = $dehydrated::letsencrypt_cas[$letsencrypt_ca]['url']
   $letsencrypt_ca_hash = $dehydrated::letsencrypt_cas[$letsencrypt_ca]['hash']

--- a/manifests/certificate/request.pp
+++ b/manifests/certificate/request.pp
@@ -132,6 +132,7 @@ define dehydrated::certificate::request (
         'crt_serial'                               => $crt_serial,
         'request_fqdn_dir'                         => $request_fqdn_dir,
         'request_base_dir'                         => $request_base_dir,
+        'request_account_dir'                      => $request_account_dir,
         'dehydrated_environment'                   => $dehydrated_environment,
         'dehydrated_hook_script'                   => $dehydrated_hook_script,
         'dehydrated_domain_validation_hook_script' => $dehydrated_domain_validation_hook_script,

--- a/manifests/certificate/request.pp
+++ b/manifests/certificate/request.pp
@@ -54,7 +54,11 @@ define dehydrated::certificate::request (
 
   $request_fqdn_dir = [$dehydrated_requests_dir, $request_fqdn].join($dehydrated::params::path_seperator)
   $request_base_dir = [$request_fqdn_dir, $base_filename].join($dehydrated::params::path_seperator)
-  $request_account_dir = [$request_fqdn_dir, 'accounts'].join($dehydrated::params::path_seperator)
+  $request_account_dir = if $dehydrated::accounts_per_agent {
+    [$request_fqdn_dir, 'accounts'].join($dehydrated::params::path_seperator)
+  } else {
+    [$dehydrated::dehydrated_base_dir, 'accounts'].join($dehydrated::params::path_seperator)
+  }
   $csr_file = [$request_base_dir, "${base_filename}.csr"].join($dehydrated::params::path_seperator)
   $dehydrated_config = [$request_base_dir, "${base_filename}.config"].join($dehydrated::params::path_seperator)
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -102,6 +102,8 @@
 # @param dehydrated_contact_email
 #   Contact email address for created accounts. We'll create one account for each
 #   puppet host.
+# @param accounts_per_agent
+#   Create one ACME account per puppet client (true; the default), or one account globally.
 # @param dehydrated_status_file
 #   File the dehydrated job runner will dump its status into. Pretty printed JSON.
 # @param dehydrated_monitoring_status_file
@@ -162,6 +164,7 @@ class dehydrated (
   Optional[Dehydrated::Hook] $dehydrated_domain_validation_hook = $dehydrated::params::dehydrated_domain_validation_hook,
   Optional[Dehydrated::Hook] $dehydrated_hook = "${challengetype}.sh",
   Optional[Dehydrated::Email] $dehydrated_contact_email = $dehydrated::params::dehydrated_contact_email,
+  Boolean $accounts_per_agent = true,
 
   Boolean $manage_user = $dehydrated::params::manage_user,
   Boolean $manage_packages = $dehydrated::params::manage_packages,


### PR DESCRIPTION
Support having a single LE account for requests from all puppet agents.

This makes it feasible to then add that puppet account to a zone's CAA records.