### PR TITLE
support setting rsa key sizes in more places

### DIFF
--- a/lib/puppet/type/dehydrated_key.rb
+++ b/lib/puppet/type/dehydrated_key.rb
@@ -33,7 +33,7 @@ Puppet::Type.newtype(:dehydrated_key) do
 
   newparam(:size) do
     desc 'The key size, used for RSA only.'
-    defaultto 2048
+    defaultto 3072
 
     validate do |value|
       unless (value.to_i.to_s == value) || (value.to_i == value)

--- a/manifests/certificate.pp
+++ b/manifests/certificate.pp
@@ -36,6 +36,8 @@
 #   Algorithm / elliptic-curve you want to use. Supported: rsa, secp384r1, prime256v1.
 #   Defaults to $dehydrated::algorithm, which defaults to 'rsa'.
 #   You can specify a different algorithm for each certificate here.
+# @param key_size
+#   Size of the key if we create a new one.  Only used if algorithm is 'rsa'.
 # @param dh_param_size
 #   Size of the DH params we should generate. Defaults to $dehydrated::dh_param_size,
 #   which defaults to 2048. You can specify a different DH param size for each certificate here.
@@ -77,6 +79,7 @@ define dehydrated::certificate (
   Array[Dehydrated::DN] $subject_alternative_names = [],
   Dehydrated::Challengetype $challengetype = $dehydrated::challengetype,
   Dehydrated::Algorithm $algorithm = $dehydrated::algorithm,
+  Integer[768] $key_size = $dehydrated::key_size,
   Integer[768] $dh_param_size = $dehydrated::dh_param_size,
   Stdlib::Fqdn $dehydrated_host = $dehydrated::dehydrated_host,
   Hash $dehydrated_environment = $dehydrated::dehydrated_environment,
@@ -123,6 +126,7 @@ define dehydrated::certificate (
     subject_alternative_names => $subject_alternative_names,
     key_password              => $key_password,
     algorithm                 => $algorithm,
+    size                      => $key_size,
   }
 
   $ready_for_merge = pick(

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -57,6 +57,9 @@
 #   Default algorithm / elliptic-curve you want to use. Supported: rsa, secp384r1, prime256v1.
 #   Defaults to rsa. You can specify a different algorithm for each certificate,
 #   see dehydrated::certificate.
+# @param key_size
+#   Size of the key if we create a new one.  Only used if algorithm is 'rsa'.
+#   You can specify a different size for each certificate; see dehydrated::certificate.
 # @param dehydrated_base_dir
 #   Only used if $facts['fqdn'] == $dehydrated::dehydrated_host. Path where the dehydrated
 #   script and configurations/csrs are being stored. Defaults to '/opt/dehydrated'.
@@ -148,6 +151,7 @@ class dehydrated (
   Integer[768] $dh_param_size = $dehydrated::params::dh_param_size,
   Dehydrated::Challengetype $challengetype = $dehydrated::params::challengetype,
   Dehydrated::Algorithm $algorithm = $dehydrated::params::algorithm,
+  Integer[768] $key_size = $dehydrated::params::key_size,
 
   Stdlib::Absolutepath $dehydrated_base_dir = $dehydrated::params::dehydrated_base_dir,
   Stdlib::Absolutepath $dehydrated_git_dir = "${dehydrated_base_dir}/dehydrated",

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -108,6 +108,7 @@ class dehydrated::params {
   $dh_param_size = 2048
   $challengetype = 'dns-01'
   $algorithm = 'rsa'
+  $key_size = 3072 # for rsa only
 
   # dehydrated setting
   $dehydrated_git_url = 'https://github.com/dehydrated-io/dehydrated.git'


### PR DESCRIPTION
While dehydrated::certificate::csr already had a key parameter, there was no way to populate it via dehydrated::certificate or by default.

Now both dehydrated::certificate as well as dehydrated have a key_size parameter to set the size of newly generated RSA keys.

Also, change the default key size to 3072 from 2048.