### PR TITLE
Allow undef return value for dehydrated::file function

### DIFF
--- a/lib/puppet/functions/dehydrated/file.rb
+++ b/lib/puppet/functions/dehydrated/file.rb
@@ -9,7 +9,7 @@ Puppet::Functions.create_function(:'dehydrated::file') do
   dispatch :getfile do
     required_param 'String', :files
     optional_repeated_param 'String', :more_files
-    return_type 'String'
+    return_type 'Optional[String]'
   end
 
   def getfile(files, *more_files)


### PR DESCRIPTION
#### Pull Request (PR) description

While debugging another issue, I came a cross the following evaluation error in `dehydrated::file`:

```
Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Resource Statement, Evaluation Error: Error while evaluating a Function Call, value returned from function 'getfile' has wrong type, expects a String value, got Undef (file: /etc/puppetlabs/code/environments/production/modules/dehydrated/manifests/certificate/collect.pp, line: 47, column: 12) (file: /etc/puppetlabs/code/environments/production/modules/dehydrated/manifests/init.pp, line: 292) on XXXXX
```

While not being the cause of my original issue, this evaluation error prevented me from getting further debugging information, which I needed to fix my problem.

#### This Pull Request (PR) fixes the following issues

This pull request fixes the return type of `dehydrated::file` to also accept `undef` as return value, which is returned in case of an error.

I believe this is the intended behavior, since it matches the remaining code, handling `undef` in case of an error.